### PR TITLE
Fixes the issue where the prepared statement's plan_name is truncated

### DIFF
--- a/lib/PgSqlExecutor.php
+++ b/lib/PgSqlExecutor.php
@@ -205,7 +205,7 @@ class PgSqlExecutor implements Executor {
      */
     public function execute(string $sql, ...$params): Promise {
         return call(function () use ($sql, $params) {
-            return $this->createResult(yield from $this->send("pg_send_query_params", sha1($sql), $params));
+            return $this->createResult(yield from $this->send("pg_send_query_params", $sql, $params));
         });
     }
 
@@ -214,8 +214,9 @@ class PgSqlExecutor implements Executor {
      */
     public function prepare(string $sql): Promise {
         return call(function () use ($sql) {
-            yield from $this->send("pg_send_prepare", sha1($sql), $sql);
-            return new PgSqlStatement($sql, $this->executeCallback);
+            $name = "amphp" . sha1($sql);
+            yield from $this->send("pg_send_prepare", $name, $sql);
+            return new PgSqlStatement($name, $sql, $this->executeCallback);
         });
     }
 

--- a/lib/PgSqlExecutor.php
+++ b/lib/PgSqlExecutor.php
@@ -205,7 +205,7 @@ class PgSqlExecutor implements Executor {
      */
     public function execute(string $sql, ...$params): Promise {
         return call(function () use ($sql, $params) {
-            return $this->createResult(yield from $this->send("pg_send_query_params", $sql, $params));
+            return $this->createResult(yield from $this->send("pg_send_query_params", sha1($sql), $params));
         });
     }
 
@@ -214,7 +214,7 @@ class PgSqlExecutor implements Executor {
      */
     public function prepare(string $sql): Promise {
         return call(function () use ($sql) {
-            yield from $this->send("pg_send_prepare", $sql, $sql);
+            yield from $this->send("pg_send_prepare", sha1($sql), $sql);
             return new PgSqlStatement($sql, $this->executeCallback);
         });
     }

--- a/lib/PgSqlStatement.php
+++ b/lib/PgSqlStatement.php
@@ -6,6 +6,9 @@ use Amp\Promise;
 
 class PgSqlStatement implements Statement {
     /** @var string */
+    private $name;
+
+    /** @var string */
     private $sql;
 
     /** @var callable */
@@ -15,7 +18,8 @@ class PgSqlStatement implements Statement {
      * @param string $sql
      * @param callable $execute
      */
-    public function __construct(string $sql, callable $execute) {
+    public function __construct(string $name, string $sql, callable $execute) {
+        $this->name = $name;
         $this->sql = $sql;
         $this->execute = $execute;
     }
@@ -35,6 +39,6 @@ class PgSqlStatement implements Statement {
      * @throws \Amp\Postgres\FailureException If executing the statement fails.
      */
     public function execute(...$params): Promise {
-        return ($this->execute)(sha1($this->sql), $params);
+        return ($this->execute)($this->name, $params);
     }
 }

--- a/lib/PgSqlStatement.php
+++ b/lib/PgSqlStatement.php
@@ -35,6 +35,6 @@ class PgSqlStatement implements Statement {
      * @throws \Amp\Postgres\FailureException If executing the statement fails.
      */
     public function execute(...$params): Promise {
-        return ($this->execute)($this->sql, $params);
+        return ($this->execute)(sha1($this->sql), $params);
     }
 }

--- a/lib/PqExecutor.php
+++ b/lib/PqExecutor.php
@@ -215,14 +215,14 @@ class PqExecutor implements Executor {
      * {@inheritdoc}
      */
     public function execute(string $sql, ...$params): Promise {
-        return new Coroutine($this->send([$this->handle, "execParamsAsync"], sha1($sql), $params));
+        return new Coroutine($this->send([$this->handle, "execParamsAsync"], $sql, $params));
     }
 
     /**
      * {@inheritdoc}
      */
     public function prepare(string $sql): Promise {
-        return new Coroutine($this->send([$this->handle, "prepareAsync"], sha1($sql), $sql));
+        return new Coroutine($this->send([$this->handle, "prepareAsync"], "amphp" .sha1($sql), $sql));
     }
 
     /**

--- a/lib/PqExecutor.php
+++ b/lib/PqExecutor.php
@@ -215,14 +215,14 @@ class PqExecutor implements Executor {
      * {@inheritdoc}
      */
     public function execute(string $sql, ...$params): Promise {
-        return new Coroutine($this->send([$this->handle, "execParamsAsync"], $sql, $params));
+        return new Coroutine($this->send([$this->handle, "execParamsAsync"], sha1($sql), $params));
     }
 
     /**
      * {@inheritdoc}
      */
     public function prepare(string $sql): Promise {
-        return new Coroutine($this->send([$this->handle, "prepareAsync"], $sql, $sql));
+        return new Coroutine($this->send([$this->handle, "prepareAsync"], sha1($sql), $sql));
     }
 
     /**


### PR DESCRIPTION
Currently the raw query is used for the prepared statement name (plan_name).

But postgres silently truncates names after 63 characters. This fixes hashes the query using `sha1` to use as the name.

I couldn't test pq myself as I don't have it running so if somebody could test it that would be great.