### PR TITLE
Documentation Fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use Amp\Postgres;
 use Amp\Postgres\ConnectionConfig;
 
 Amp\Loop::run(function () {
-    $config = ConnectionConfig::fromString("host=localhost user=postgres dbname=test");
+    $config = Postgres\ConnectionConfig::fromString("host=localhost user=postgres dbname=test");
 
     /** @var Postgres\Pool $pool */
     $pool = Postgres\pool($config);


### PR DESCRIPTION
Fixed "PHP Fatal error:  Uncaught Error: Class 'ConnectionConfig' not found"