### PR TITLE
PgSql now shows text of failed query in Exception

### DIFF
--- a/src/PgSqlHandle.php
+++ b/src/PgSqlHandle.php
@@ -248,7 +248,7 @@ final class PgSqlHandle implements Handle
      * @throws FailureException
      * @throws QueryError
      */
-    private function createResult($result, &$sql)
+    private function createResult($result, $sql)
     {
         switch (\pg_result_status($result, \PGSQL_STATUS_LONG)) {
             case \PGSQL_EMPTY_QUERY:
@@ -398,6 +398,7 @@ final class PgSqlHandle implements Handle
                             foreach (self::DIAGNOSTIC_CODES as $fieldCode => $description) {
                                 $diagnostics[$description] = \pg_result_error_field($result, $fieldCode);
                             }
+                            $diagnostics['sql'] = $modifiedSql;
                             throw new QueryExecutionError(\pg_result_error($result), $diagnostics);
 
                         case \PGSQL_BAD_RESPONSE:

--- a/src/PqHandle.php
+++ b/src/PqHandle.php
@@ -232,7 +232,7 @@ final class PqHandle implements Handle
 
             case pq\Result::NONFATAL_ERROR:
             case pq\Result::FATAL_ERROR:
-                throw new QueryExecutionError($result->errorMessage, array_merge($result->diag, ['sql' => $args[0] ?? '']));
+                throw new QueryExecutionError($result->errorMessage, \array_merge($result->diag, ['sql' => $args[0] ?? '']));
 
             case pq\Result::BAD_RESPONSE:
                 throw new FailureException($result->errorMessage);

--- a/src/PqHandle.php
+++ b/src/PqHandle.php
@@ -232,7 +232,7 @@ final class PqHandle implements Handle
 
             case pq\Result::NONFATAL_ERROR:
             case pq\Result::FATAL_ERROR:
-                throw new QueryExecutionError($result->errorMessage, $result->diag);
+                throw new QueryExecutionError($result->errorMessage, array_merge($result->diag, ['sql' => $args[0] ?? '']));
 
             case pq\Result::BAD_RESPONSE:
                 throw new FailureException($result->errorMessage);

--- a/src/QueryExecutionError.php
+++ b/src/QueryExecutionError.php
@@ -11,7 +11,7 @@ class QueryExecutionError extends QueryError
 
     public function __construct(string $message, array $diagnostics, \Throwable $previous = null)
     {
-        parent::__construct($message, 0, $previous);
+        parent::__construct($message, $diagnostics['sql'], $previous);
         $this->diagnostics = $diagnostics;
     }
 

--- a/test/AbstractLinkTest.php
+++ b/test/AbstractLinkTest.php
@@ -117,6 +117,7 @@ abstract class AbstractLinkTest extends AsyncTestCase
         } catch (QueryExecutionError $exception) {
             $diagnostics  = $exception->getDiagnostics();
             $this->assertArrayHasKey("sqlstate", $diagnostics);
+            $this->assertEquals('SELECT & FROM test', $diagnostics['sql']);
         }
     }
 


### PR DESCRIPTION
All PgSQL queries didn't show full SQL ext of failed query.
This PR add functionality to show failed query text instead of "Current query was 0"