### PR TITLE
Fixed case where operators containing question mark were erroneously substituted by the parameter parser

### DIFF
--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -5,12 +5,28 @@ namespace Amp\Postgres\Internal;
 use function Amp\Postgres\cast;
 
 const STATEMENT_PARAM_REGEX = <<<'REGEX'
-~(["'`])(?:\\(?:\\|\1)|(?!\1).)*+\1(*SKIP)(*FAIL)|(\$(\d+)|\?)|(?<!:):([a-zA-Z_][a-zA-Z0-9_]*)~ms
+[
+    # Skip all quoted groups.
+    (['"])(?:\\(?:\\|\1)|(?!\1).)*+\1(*SKIP)(*FAIL)
+    |
+    # Unnamed parameters.
+    (
+        \$(?:\d+)
+        |
+        # Match all question marks except those surrounded by "operator"-class characters on either side.
+        (?<!(?<operators>[-+\\*/<>=~!@#%^&|`?]))
+        \?
+        (?!\g<operators>)
+    )
+    |
+    # Named parameters.
+    (?<!:):(?:[a-zA-Z_][a-zA-Z0-9_]*)
+]msxS
 REGEX;
 
 /**
  * @param string $sql SQL statement with named and unnamed placeholders.
- * @param array $names [Output] Array of parameter positions mapped to names and/or indexed locations.
+ * @param array|null $names [Output] Array of parameter positions mapped to names and/or indexed locations.
  *
  * @return string SQL statement with Postgres-style placeholders
  */

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -11,16 +11,16 @@ const STATEMENT_PARAM_REGEX = <<<'REGEX'
     |
     # Unnamed parameters.
     (
-        \$(?:\d+)
+        \$(\d+)
         |
         # Match all question marks except those surrounded by "operator"-class characters on either side.
-        (?<!(?<operators>[-+\\*/<>=~!@#%^&|`?]))
+        (?<!(?<operators>[-+\\*/<>~!@#%^&|`?]))
         \?
-        (?!\g<operators>)
+        (?!\g<operators>|=)
     )
     |
     # Named parameters.
-    (?<!:):(?:[a-zA-Z_][a-zA-Z0-9_]*)
+    (?<!:):([a-zA-Z_][a-zA-Z0-9_]*)
 ]msxS
 REGEX;
 
@@ -37,7 +37,7 @@ function parseNamedParams(string $sql, ?array &$names): string
         static $index = 0, $unnamed = 0, $numbered = 1;
 
         if (isset($matches[4])) {
-            $names[$index] = $matches[4];
+            $names[$index] = $matches[5];
         } elseif ($matches[2] === '?') {
             $names[$index] = $unnamed++;
         } else {

--- a/test/InternalFunctionsTest.php
+++ b/test/InternalFunctionsTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Amp\Postgres\Test;
+
+use PHPUnit\Framework\TestCase;
+use function Amp\Postgres\Internal\parseNamedParams;
+
+final class InternalFunctionsTest extends TestCase
+{
+    /**
+     * Tests that the JSONB `@?` operator is not substituted by the parameter parser.
+     *
+     * @see parseNamedParams
+     * @see https://github.com/amphp/postgres/issues/39
+     */
+    public function testParseJsonbOperator(): void
+    {
+        self::assertSame(
+            $sql = "SELECT * FROM foo WHERE bar::jsonb @? '$[*] ? (@.baz > 0)'",
+            parseNamedParams($sql, $names)
+        );
+    }
+}

--- a/test/InternalFunctionsTest.php
+++ b/test/InternalFunctionsTest.php
@@ -25,6 +25,8 @@ final class InternalFunctionsTest extends TestCase
             'Bare' => ['SELECT ?', 'SELECT $1'],
             'Parenthesized' => ['SELECT (?)', 'SELECT ($1)'],
             'Row constructor' => ['SELECT (?, ?)', 'SELECT ($1, $2)'],
+            // Special-case exclude the =? operator to permit the following usage.
+            '=? operator' => ['UPDATE foo SET bar=?', 'UPDATE foo SET bar=$1']
         ];
     }
 


### PR DESCRIPTION
Fixes #39.