### PR TITLE
Fix PqHandle

### DIFF
--- a/src/PqHandle.php
+++ b/src/PqHandle.php
@@ -34,7 +34,7 @@ final class PqHandle implements Handle
     private $await;
 
     /** @var Emitter[] */
-    private $listeners;
+    private $listeners = [];
 
     /** @var array<string, object{refCount: int, promise: Promise<string>, statement: pq\Statement, sql: string}> */
     private $statements = [];


### PR DESCRIPTION
Several times now I have seen this error:

```
[ErrorException]                                                      
Warning: foreach() argument must be of type array|object, null given  

Exception trace:
  at /app/vendor/amphp/postgres/src/PqHandle.php:68
 Amp\Postgres\PqHandle::Amp\Postgres\{closure}() at /app/vendor/amphp/amp/lib/Loop/EventDriver.php:63
 Amp\Loop\EventDriver->Amp\Loop\{closure}() at n/a:n/a
 EventBase->loop() at /app/vendor/amphp/amp/lib/Loop/EventDriver.php:255
 Amp\Loop\EventDriver->dispatch() at /app/vendor/amphp/amp/lib/Loop/Driver.php:138
 Amp\Loop\Driver->tick() at /app/vendor/amphp/amp/lib/Loop/Driver.php:72
 Amp\Loop\Driver->run() at /app/vendor/amphp/amp/lib/Loop/EventDriver.php:206
 Amp\Loop\EventDriver->run() at /app/vendor/amphp/amp/lib/Loop.php:95
 Amp\Loop::run() at /app/src/Module/Core/Console/RunLoopCommand.php:77
 App\Module\Core\Console\RunLoopCommand->execute() at /app/vendor/symfony/console/Command/Command.php:299
 Symfony\Component\Console\Command\Command->run() at /app/vendor/symfony/console/Application.php:996
 Symfony\Component\Console\Application->doRunCommand() at /app/vendor/symfony/framework-bundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /app/vendor/symfony/console/Application.php:295
 Symfony\Component\Console\Application->doRun() at /app/vendor/symfony/framework-bundle/Console/Application.php:82
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /app/vendor/symfony/console/Application.php:167
 Symfony\Component\Console\Application->run() at /app/bin/console:25

```

Sadly it's pretty much random so I have no idea what the circumstances are nor can I give you a way to reproduce it. It started to appear when I tried to upgrade to amphp/postgres v1.4.