### PR TITLE
fix(transaction): transaction is never released

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "ext-pgsql": "*",
         "ext-pq": "*",
-        "amphp/phpunit-util": "^2-dev",
+        "amphp/phpunit-util": "^v3.x-dev",
         "phpunit/phpunit": "^9",
         "amphp/php-cs-fixer-config": "dev-master",
         "psalm/phar": "^4.10"

--- a/src/PgSqlHandle.php
+++ b/src/PgSqlHandle.php
@@ -482,7 +482,7 @@ final class PgSqlHandle implements Handle
         }
 
         EventLoop::enable($this->poll);
-        return new ConnectionListener($source->asPipeline(), $channel, \Closure::fromCallable([$this, 'unlisten']));
+        return new ConnectionListener($source->pipe(), $channel, \Closure::fromCallable([$this, 'unlisten']));
     }
 
     /**

--- a/src/PqHandle.php
+++ b/src/PqHandle.php
@@ -474,7 +474,7 @@ final class PqHandle implements Handle
         }
 
         EventLoop::enable($this->poll);
-        return new ConnectionListener($source->asPipeline(), $channel, \Closure::fromCallable([$this, 'unlisten']));
+        return new ConnectionListener($source->pipe(), $channel, \Closure::fromCallable([$this, 'unlisten']));
     }
 
     /**


### PR DESCRIPTION
Given the following example:

```php
$config = Postgres\ConnectionConfig::fromString('host=127.0.0.1 port=32770 user=main password=main');
$link = Postgres\connect($config);
$trans = $link->beginTransaction();
$trans->query('DROP TABLE IF EXISTS test_users');
$trans->query('CREATE TABLE IF NOT EXISTS test_users (
        id SERIAL PRIMARY KEY,
        username VARCHAR(30) NOT NULL,
        email VARCHAR(1024) NOT NULL,
        password VARCHAR(1024) NOT NULL,
        status INT NOT NULL
    )');
$trans->commit();

$link->execute('INSERT INTO test_users (username, email, password, status) VALUES (?,?,?,?)', ['azjezz', 'azjezz@protonmail.com', '123456789', 1]);
$users = $link->execute('SELECT * FROM test_users');

var_dump(\iterator_to_array($users));
```

Prior to this change, i encounter the following error: 

```shell
> php users.php
PHP Fatal error:  Uncaught Error: Event loop terminated without resuming the current suspension in /home/azjezz/Projects/neutomic/neu/vendor/revolt/event-loop/src/EventLoop/Internal/DriverSuspension.php:86
Stack trace:
#0 /home/azjezz/Projects/neutomic/neu/vendor/amphp/amp/src/Future.php(244): Revolt\EventLoop\Internal\DriverSuspension->suspend()
#1 /home/azjezz/Projects/neutomic/neu/vendor/amphp/postgres/src/Connection.php(75): Amp\Future->await()
#2 /home/azjezz/Projects/neutomic/neu/vendor/amphp/postgres/src/Connection.php(113): Amp\Postgres\Connection->awaitPending()
#3 /home/azjezz/Projects/neutomic/neu/example/users.php(25): Amp\Postgres\Connection->execute('INSERT INTO tes...', Array)
#4 {main}
  thrown in /home/azjezz/Projects/neutomic/neu/vendor/revolt/event-loop/src/EventLoop/Internal/DriverSuspension.php on line 86

Fatal error: Uncaught Error: Event loop terminated without resuming the current suspension in /home/azjezz/Projects/neutomic/neu/vendor/revolt/event-loop/src/EventLoop/Internal/DriverSuspension.php:86
Stack trace:
#0 /home/azjezz/Projects/neutomic/neu/vendor/amphp/amp/src/Future.php(244): Revolt\EventLoop\Internal\DriverSuspension->suspend()
#1 /home/azjezz/Projects/neutomic/neu/vendor/amphp/postgres/src/Connection.php(75): Amp\Future->await()
#2 /home/azjezz/Projects/neutomic/neu/vendor/amphp/postgres/src/Connection.php(113): Amp\Postgres\Connection->awaitPending()
#3 /home/azjezz/Projects/neutomic/neu/example/users.php(25): Amp\Postgres\Connection->execute('INSERT INTO tes...', Array)
#4 {main}
  thrown in /home/azjezz/Projects/neutomic/neu/vendor/revolt/event-loop/src/EventLoop/Internal/DriverSuspension.php on line 86

```

Now, this works as expected:

```shell
> php users.php
array(1) {
  [0]=>
  array(5) {
    ["id"]=>
    int(1)
    ["username"]=>
    string(6) "azjezz"
    ["email"]=>
    string(21) "azjezz@protonmail.com"
    ["password"]=>
    string(9) "123456789"
    ["status"]=>
    int(1)
  }
}
```

( note: the example above uses the v2 branch, but i'm assuming the issue is also present in v1 )