### PR TITLE
Tolerate deallocation of statements the server has already dropped

### DIFF
--- a/src/Internal/PgSqlHandle.php
+++ b/src/Internal/PgSqlHandle.php
@@ -413,7 +413,17 @@ final class PgSqlHandle extends AbstractHandle
                 return; // Statement already deallocated.
             }
 
-            $this->query(\sprintf("DEALLOCATE %s", $name));
+            try {
+                // Send the DEALLOCATE without building a result object: an error result
+                // must not be processed through createResult(), whose fatal-error drain
+                // would consume results belonging to an operation dispatched after this
+                // one and leave that operation awaiting a response forever.
+                $this->send(\pg_send_query(...), \sprintf("DEALLOCATE %s", $name));
+            } catch (\Throwable) {
+                // Ignore failures: the server may have already dropped the statement,
+                // e.g. via the DISCARD ALL issued when the pool resets connections.
+            }
+
             unset($this->statements[$name]);
         });
         $storage->future->ignore();

--- a/src/Internal/PqHandle.php
+++ b/src/Internal/PqHandle.php
@@ -338,9 +338,16 @@ final class PqHandle extends AbstractHandle
                 return; // Statement already deallocated.
             }
 
-            $this->send(null, $statement->deallocateAsync(...));
+            try {
+                $this->send(null, $statement->deallocateAsync(...));
+            } catch (\Throwable) {
+                // Ignore failures: the server may have already dropped the statement,
+                // e.g. via the DISCARD ALL issued when the pool resets connections.
+            }
+
             unset($this->statements[$name]);
         });
+        $storage->future->ignore();
     }
 
     #[\Override]

--- a/test/StatementDeallocateTest.php
+++ b/test/StatementDeallocateTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Postgres\Test;
+
+use Amp\PHPUnit\AsyncTestCase;
+use Amp\Postgres\PostgresConfig;
+use Amp\Postgres\PostgresConnectionPool;
+use Revolt\EventLoop;
+
+/**
+ * @requires extension pgsql
+ */
+class StatementDeallocateTest extends AsyncTestCase
+{
+    public function testDeallocateRacingConnectionResetDoesNotBreakSubsequentOperations(): void
+    {
+        if (EventLoop::getDriver()->getHandle() instanceof \EvLoop) {
+            $this->markTestSkipped("ext-pgsql is not compatible with pecl-ev");
+        }
+
+        $this->setTimeout(5);
+
+        $pool = new PostgresConnectionPool(
+            PostgresConfig::fromString('host=localhost user=postgres password=postgres'),
+            1,
+        );
+
+        try {
+            $statement = $pool->prepare('SELECT 1 AS value');
+            $result = $statement->execute();
+            \iterator_to_array($result);
+
+            // Dropping the statement and result queues a DEALLOCATE for the prepared
+            // statement, while the pool's DISCARD ALL reset on the next checkout drops
+            // it server-side. The failing DEALLOCATE must not consume responses that
+            // belong to operations dispatched after it.
+            unset($result, $statement);
+
+            for ($i = 1; $i <= 3; ++$i) {
+                $rows = \iterator_to_array($pool->query(\sprintf('SELECT %d AS value', $i)));
+                self::assertSame($i, $rows[0]['value']);
+            }
+
+            $statement = $pool->prepare('SELECT 2 AS value');
+            $rows = \iterator_to_array($statement->execute());
+            self::assertSame(2, $rows[0]['value']);
+        } finally {
+            $pool->close();
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to amphp/sql-common#8. Deallocating a prepared statement can race the pool's `DISCARD ALL` connection reset: `DISCARD ALL` drops every server-side prepared statement, so the queued `DEALLOCATE` for a statement closed just before the connection was reset fails with `prepared statement "..." does not exist`.

Two problems fall out of that on the pgsql backend:

1. The `DEALLOCATE` ran through `query()`, so its error result went through `createResult()`. The fatal-error branch there drains the connection (`while (pg_connection_busy && pg_get_result)`), which can consume responses belonging to an operation dispatched after the deallocation. That operation then awaits a reply that never comes, wedging the connection permanently. With sql-common#8 in place (declined statements are closed), this shape reproduces deterministically:

```php
$pool = new PostgresConnectionPool(PostgresConfig::fromString('...'), 1);

$statement = $pool->prepare('SELECT 1');
$result = $statement->execute();
iterator_to_array($result);

// $result stays referenced; the declined statement is closed, queueing DEALLOCATE.
// The next checkout runs DISCARD ALL, the DEALLOCATE fails, and its error drain
// eats the response of the execute below, which never completes.
$second = $pool->prepare('SELECT 2');
iterator_to_array($second->execute());
```

2. On the pq backend the failure was not drained but still errored an unobserved future.

Fix: send the `DEALLOCATE` without routing it through result processing and tolerate failure on both backends; the statement being gone is the desired end state either way. The statement cache entry is now removed regardless of the outcome.

The new `StatementDeallocateTest` exercises deallocation racing `DISCARD ALL` on a single-connection pool; the deterministic wedge above needs sql-common#8 to trigger, so it is documented here rather than encoded as a test that would fail against the current sql-common release.

Test run: 121 PgSql tests + the new test green against PostgreSQL 16 (pq suite skipped, ext-pq unavailable locally).
